### PR TITLE
メールアドレスの3種類によるユーザー登録ができるミニアプリを作成

### DIFF
--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -9,21 +9,21 @@
     = f.label :email
     %br/
     = f.email_field :email, autofocus: true, autocomplete: "email"
-    - if @sns_id.present?
-      = hidden_field_tag :sns_auth, true
-    - else
-  .field
-    = f.label :password
-    - if @minimum_password_length
-      %em
-        (#{@minimum_password_length} characters minimum)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
 
+  - if @sns_id.present?
+    = hidden_field_tag :sns_auth, true
+  - else
+    .field
+      = f.label :password
+      - if @minimum_password_length
+        %em
+          (#{@minimum_password_length} characters minimum)
+      %br/
+      = f.password_field :password, autocomplete: "new-password"
+    .field
+      = f.label :password_confirmation
+      %br/
+      = f.password_field :password_confirmation, autocomplete: "new-password"
   .actions
   .field
     = f.label :firstname
@@ -39,4 +39,5 @@
     = f.date_select :birthday, start_year: 1950, end_year: 2019
     = f.submit "Sign up"
 = render "devise/shared/links"
+
 

--- a/db/migrate/20200203024520_devise_create_users.rb
+++ b/db/migrate/20200203024520_devise_create_users.rb
@@ -46,3 +46,5 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
     # add_index :users, :unlock_token,         unique: true
   end
 end
+
+

--- a/db/migrate/20200203024520_devise_create_users.rb
+++ b/db/migrate/20200203024520_devise_create_users.rb
@@ -46,5 +46,3 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
     # add_index :users, :unlock_token,         unique: true
   end
 end
-
-


### PR DESCRIPTION
#What
Facebook,Google,メールアドレスの3種類によるユーザー登録ができるサンプルアプリを作成

＃why
Facebook,Google,メールアドレスの3種類によるユーザー登録機能を、fake_mercに導入する必要があるため

https://gyazo.com/5bec0a35a4705ba1e483ad97ddc24ce7